### PR TITLE
fix: Add missing contact link to main navigation

### DIFF
--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -10,7 +10,8 @@ const sections = [
   { href: '#results', label: 'Results' },
   { href: '#pricing', label: 'Pricing' },
   { href: '#courses', label: 'Courses' },
-  { href: '#about', label: 'About' }
+  { href: '#about', label: 'About' },
+  { href: '#contact', label: 'Contact' }
 ];
 
 export default function Nav() {


### PR DESCRIPTION
The main navigation component in `components/Nav.tsx` was missing a link to the "Contact" section. This caused inconsistencies with the page content and footer navigation.

This commit adds the "Contact" link to the `sections` array in `Nav.tsx`, ensuring the main navigation is complete and functional.